### PR TITLE
Adding suggestions for invalid class names

### DIFF
--- a/lib/levenshtein.re
+++ b/lib/levenshtein.re
@@ -1,0 +1,38 @@
+let minimum = (a, b, c) => min(a, min(b, c));
+
+/*
+ * Levenshtein distance
+ * Translated from OCaml example in Rosetta Code
+ * https://rosettacode.org/wiki/Levenshtein_distance#OCaml
+ * https://en.wikipedia.org/wiki/Levenshtein_distance
+ */
+let distance = (s, t) => {
+  let first = String.length(s)
+  and second = String.length(t);
+  let matrix = Array.make_matrix(first + 1, second + 1, 0);
+
+  for (i in 0 to first) {
+    matrix[i][0] = i;
+  };
+
+  for (j in 0 to second) {
+    matrix[0][j] = j;
+  };
+
+  for (j in 1 to second) {
+    for (i in 1 to first) {
+      if (s.[i - 1] == t.[j - 1]) {
+        matrix[i][j] = matrix[i - 1][j - 1];
+      } else {
+        matrix[i][j] =
+          minimum(
+            matrix[i - 1][j] + 1,
+            matrix[i][j - 1] + 1,
+            matrix[i - 1][j - 1] + 1,
+          );
+      };
+    };
+  };
+
+  matrix[first][second];
+};

--- a/lib/tailwind_utils.re
+++ b/lib/tailwind_utils.re
@@ -24,13 +24,11 @@ let findClosest = (className, acceptableNames) => {
     let distance = Levenshtein.distance(className, name);
     distance < bestMatch.distance ? {name, distance} : bestMatch;
   };
-  let {name, distance: _} =
-    List.fold_right(
-      testCloser,
-      acceptableNames,
-      {name: "", distance: max_int},
-    );
-  name;
+  List.fold_right(
+    testCloser,
+    acceptableNames,
+    {name: "", distance: max_int},
+  );
 };
 
 /********************** CSS PARSER HELPERS *************************/
@@ -124,7 +122,7 @@ let checkAcceptable = (classNames, loc, tailwindFile) => {
     Printf.sprintf(
       "Class name not found: %s. Did you mean %s?",
       invalidClassName,
-      closest,
+      closest.name,
     );
   };
   // TODO add a suggested className as part of the error message here

--- a/test/bucklescript/tailwind.css
+++ b/test/bucklescript/tailwind.css
@@ -6,4 +6,7 @@
   flex-direction: row;
 }
 
+.hover\:bg-current:hover {
+  background-color: currentColor;
+}
 

--- a/test/native/lib/Test.re
+++ b/test/native/lib/Test.re
@@ -41,10 +41,9 @@ describe("Main testing module", ({test, _}) => {
 
   test("levenshtein distance", ({expect, _}) => {
     let acceptableNames = ["flex", "flex-row", "hover:bg-mono-100"];
+    let {name, _} = findClosest("bg-mono-100", acceptableNames);
 
-    expect.string(findClosest("bg-mono-100", acceptableNames)).toEqual(
-      "hover:bg-mono-100",
-    );
+    expect.string(name).toEqual("hover:bg-mono-100");
   });
 
   test("parseStylesheet throws correctly", ({expect, _}) => {

--- a/test/native/lib/Test.re
+++ b/test/native/lib/Test.re
@@ -39,6 +39,14 @@ describe("Main testing module", ({test, _}) => {
     );
   });
 
+  test("levenshtein distance", ({expect, _}) => {
+    let acceptableNames = ["flex", "flex-row", "hover:bg-mono-100"];
+
+    expect.string(findClosest("bg-mono-100", acceptableNames)).toEqual(
+      "hover:bg-mono-100",
+    );
+  });
+
   test("parseStylesheet throws correctly", ({expect, _}) => {
     let tailwindCss = {|
 .flex {


### PR DESCRIPTION
I'm using the Levenshtein distance at the moment, though this sometimes produces some weird suggestions. I'm willing to live with it, though, on the assumption people will make typos of maybe 1-2 characters.