### PR TITLE
Add detail for using a custom tailwind.config.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,15 @@ Alternatively, you can add the following rules to you bsconfig.json to re-trigge
 }
 ```
 
+If you have a custom tailwind config file, you'll need to pass it to the tailwindcss command in this manner:
+
+```json
+{
+      "name": "gen-tailwind",
+      "command": "tailwindcss build $in -o $out -c ../../tailwind.config.js"
+}
+```
+
 You might have to specify the path to tailwind.css
 
 ```json


### PR DESCRIPTION
Hey!

This adds detail on how to use a custom tailwind config file to the generator section. This is the PR suggested in #60 

BuckleScript runs the generator command in the lib/bs directory (like when using [js-post-build](https://bucklescript.github.io/docs/en/build-configuration#js-post-build)). It is then required to pass the path to the config file or any configuration is ignored and the default one is used.