### PR TITLE
Fixing whitespace issues

### DIFF
--- a/lib/utils.re
+++ b/lib/utils.re
@@ -9,7 +9,11 @@ let acceptableNames = ref(None);
 
 /* Splits a string into the individual class names */
 let getSplitClassNames = classNames => {
-  List.filter(name => name != "", String.split_on_char(' ', classNames));
+  List.filter(
+    name => String.trim(name) != "",
+    String.split_on_char(' ', classNames),
+  )
+  |> List.map(name => String.trim(name));
 };
 
 /* Remove all the backslashes from identifiers */

--- a/test/bucklescript/src/Demo.re
+++ b/test/bucklescript/src/Demo.re
@@ -1,0 +1,10 @@
+[@react.component]
+let make = () => {
+  <div
+    className=[%tw
+      "w-full h-full bg-white flex flex-col justify-center
+      items-center"
+    ]>
+    <span> "Content"->React.string </span>
+  </div>;
+};

--- a/test/native/lib/Test.re
+++ b/test/native/lib/Test.re
@@ -27,6 +27,21 @@ describe("Main methods", ({test, _}) => {
     ]);
   });
 
+  test("splitClassNames works with whitespace", ({expect, _}) => {
+    let className = "w-full h-full bg-white flex flex-col justify-center \n
+      items-center";
+
+    expect.list(getSplitClassNames(className)).toEqual([
+      "w-full",
+      "h-full",
+      "bg-white",
+      "flex",
+      "flex-col",
+      "justify-center",
+      "items-center",
+    ]);
+  });
+
   test("checkDuplicate throws correctly", ({expect, _}) => {
     let classNames = ["flex", "flex"];
 


### PR DESCRIPTION
Fixes an issue where the following code would cause a compiler error due to the newline

```reason
[%tw "flex flex-row mt-2
   justify-content"] // ERROR: Class name not found: justify-content...
```