### PR TITLE
Recursively get all classes in selector(prelude)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Actions Status](https://github.com/dylanirlbeck/tailwind-ppx/workflows/CI/badge.svg)](https://github.com/dylanirlbeck/tailwind-ppx/actions)
 [![NPM Version](https://badge.fury.io/js/%40dylanirlbeck%2Ftailwind-ppx.svg)](https://badge.fury.io/js/%40dylanirlbeck%2Ftailwind-ppx)
 
-Reason/OCaml PPX for writing compile-time validated Tailwind CSS classes.
+Reason/OCaml [PPX](https://blog.hackages.io/reasonml-ppx-8ecd663d5640) for writing compile-time validated Tailwind CSS classes.
 
 <p align="center"><img height="800" src="assets/demo.gif?raw=true" /></p>
 

--- a/lib/utils.re
+++ b/lib/utils.re
@@ -62,7 +62,7 @@ let parseStylesheet = (~containerLnum=?, ~pos=?, css) =>
 
 /* Get all the classes from a given selector (prelude) */
 let getClassesFromSelector = selector => {
-    let rec get_classes = (classes, selector) => {
+    let rec getClasses = (classes, selector) => {
       switch (selector) {
       | [] => classes
       | [
@@ -70,12 +70,12 @@ let getClassesFromSelector = selector => {
           (Component_value.Ident(ident), _),
           ...rem,
         ] =>
-        get_classes([ident, ...classes], rem)
-      | [_, ...rem] => get_classes(classes, rem)
+        getClasses([ident, ...classes], rem)
+      | [_, ...rem] => getClasses(classes, rem)
       };
     };
 
-    get_classes([], selector); 
+    getClasses([], selector); 
 }
 
 /* Parses out the valid class names from the given CSS */

--- a/test/native/lib/Test.re
+++ b/test/native/lib/Test.re
@@ -199,6 +199,45 @@ describe("Main methods", ({test, _}) => {
 });
 
 describe(
+    "getClassesFromSelector gets all classes in a given selector", ({test, _}) => {
+        test("Basic selectors", ({expect, _})=> {
+            let flex = [
+                (Component_value.Delim("."), Location.none),
+                    (Component_value.Ident("flex"), Location.none)];
+            let expectedClassNames = ["flex"];
+            expect.list(getClassesFromSelector(flex)).
+                toEqual(expectedClassNames);
+        });
+
+        test("Hover selector", ({expect, _})=> {
+            let hover = [
+                (Component_value.Delim("."), Location.none),
+            (Component_value.Ident("hover\\:bg-white"), Location.none),
+            (Component_value.Delim(":"), Location.none),
+            (Component_value.Ident("hover"), Location.none),
+            ];
+            let expectedClassNames = ["hover\\:bg-white"];
+            expect.list(getClassesFromSelector(hover)).
+                toEqual(expectedClassNames);
+        });
+
+
+        test("Multiple classnames with different pseudo classes", ({expect, _})=> {
+            let hover = [
+                (Component_value.Delim("."), Location.none),
+                    (Component_value.Ident("group"), Location.none),
+                    (Component_value.Delim(":"), Location.none),
+                    (Component_value.Ident("hover"), Location.none),
+                    (Component_value.Delim("."), Location.none),
+                    (Component_value.Ident("group-hover\\:bg-transparent"), Location.none),
+            ];
+            let expectedClassNames = ["group-hover\\:bg-transparent", "group"];
+            expect.list(getClassesFromSelector(hover)).
+                toEqual(expectedClassNames);
+        });
+    });
+
+describe(
   "getAcceptableClassNames works for different CSS selectors", ({test, _}) => {
   test("Basic selectors", ({expect, _}) => {
     let tailwindCss = {|
@@ -255,7 +294,7 @@ describe(
     }
     |};
 
-    let expectedClassNames = ["group-hover:bg-transparent"];
+    let expectedClassNames = ["group", "group-hover:bg-transparent"];
     expect.list(getAcceptableClassNames(tailwindCss) |> StringSet.elements).
       toEqual(
       expectedClassNames,


### PR DESCRIPTION
Hey!

This changes the way classes are extracted from the prelude to get all the classes that are defined in a given selector instead of manually matching the problematic classes (group-hover) and others that could be user defined. This should fix #69