### PR TITLE
tolerate multiple class definitions on same line

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,9 +1,9 @@
 function extractor(content) {
-  const matchedContent = content.match(/(?<=\[%tw ").*(?=\"\])/g);
+  const matchedContent = content.match(/(?<=\[%tw ")[^\"]*(?=\"\])/g);
 
   if (matchedContent) {
     return matchedContent.reduce((acc, curr) => {
-      curr.split(" ").forEach((p) => {
+      curr.split(" ").forEach(p => {
         const trimmed = p.trim();
 
         if (trimmed !== "") {

--- a/test/bucklescript/src/index_test.re
+++ b/test/bucklescript/src/index_test.re
@@ -37,7 +37,7 @@ describe("Extractor", () => {
         <div className="flex-row mx-auto mt-2"></div>
 
         <!-- ...but these should -->
-        <div className=[%tw "mb-2 p-6"]></div>
+        <div className=[%tw "mb-2 p-6"]></div> <div className=[%tw "mt-8 bg-blue-200"]></div>
         |},
       ),
     )
@@ -48,6 +48,8 @@ describe("Extractor", () => {
          "hover:bg-gray-200",
          "mb-2",
          "p-6",
+         "mt-8",
+         "bg-blue-200",
        |])
   })
 });


### PR DESCRIPTION
When using this ppx with bucklescript-tea and ocamlformat with ocaml syntax, I hit an issue where the regex is too greedy and ends up parsing classes like `"p-6\"]></div>",` when multiple appear on the same line. For instance, Ocamlformat ends up formatting lines with ternaries on a single line:

```ocaml
if selected then [%tw "text-white"] else [%tw "text-blue-200"] );
```