### PR TITLE
improve extractor to better match 'refmt:ed' pxx syntax

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,5 +1,5 @@
 function extractor(content) {
-  const matchedContent = content.match(/(?<=\[%tw ")[^\"]*(?=\"\])/g);
+  const matchedContent = content.match(/(?<=\%tw\s*")[^\"]*(?=\")/g);
 
   if (matchedContent) {
     return matchedContent.reduce((acc, curr) => {

--- a/test/bucklescript/src/index_test.re
+++ b/test/bucklescript/src/index_test.re
@@ -38,6 +38,27 @@ describe("Extractor", () => {
 
         <!-- ...but these should -->
         <div className=[%tw "mb-2 p-6"]></div> <div className=[%tw "mt-8 bg-blue-200"]></div>
+
+        <!-- ...and these -->
+        <div
+          className={
+            switch (test) {
+            | A =>
+              %tw
+              "bg-red-400"
+            | B =>
+              %tw
+              "bg-green-400"
+            }
+          }
+        />
+
+        <!-- ...and so should these -->
+        <div
+          className=[%tw
+            "bg-blue-400"
+          ]
+        />
         |},
       ),
     )
@@ -50,6 +71,9 @@ describe("Extractor", () => {
          "p-6",
          "mt-8",
          "bg-blue-200",
+         "bg-red-400",
+         "bg-green-400",
+         "bg-blue-400",
        |])
   })
 });


### PR DESCRIPTION
This change enables support for two cases of "refmt":ed pxx syntax as reported in https://github.com/dylanirlbeck/tailwind-ppx/issues/115

Note: extractor now does not consider the `[]`-brackets normally surrounding the `%tw` ppx macros