### PR TITLE
Restore proper NPM package name

### DIFF
--- a/.github/workflows/bundle-release.js
+++ b/.github/workflows/bundle-release.js
@@ -1,29 +1,29 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
-console.log('Creating package.json');
+console.log("Creating package.json");
 
 // From the project root pwd
-const mainPackageJsonPath = fs.existsSync('esy.json')
-  ? 'esy.json'
-  : 'package.json';
+const mainPackageJsonPath = fs.existsSync("esy.json")
+  ? "esy.json"
+  : "package.json";
 
 const exists = fs.existsSync(mainPackageJsonPath);
 if (!exists) {
-  console.error('No package.json or esy.json at ' + mainPackageJsonPath);
+  console.error("No package.json or esy.json at " + mainPackageJsonPath);
   process.exit(1);
 }
 // Now require from this script's location.
-const mainPackageJson = require(path.join('..', '..', mainPackageJsonPath));
+const mainPackageJson = require(path.join("..", "..", mainPackageJsonPath));
 const bins = Array.isArray(mainPackageJson.esy.release.bin)
   ? mainPackageJson.esy.release.bin.reduce(
-      (acc, curr) => Object.assign({ [curr]: 'bin/' + curr }, acc),
+      (acc, curr) => Object.assign({ [curr]: "bin/" + curr }, acc),
       {}
     )
   : Object.keys(mainPackageJson.esy.release.bin).reduce(
       (acc, currKey) =>
         Object.assign(
-          { [currKey]: 'bin/' + mainPackageJson.esy.release.bin[currKey] },
+          { [currKey]: "bin/" + mainPackageJson.esy.release.bin[currKey] },
           acc
         ),
       {}
@@ -36,74 +36,74 @@ const rewritePrefix =
 
 const packageJson = JSON.stringify(
   {
-    name: mainPackageJson.name,
+    name: "@dylanirlbeck/tailwind-ppx",
     version: mainPackageJson.version,
     license: mainPackageJson.license,
     description: mainPackageJson.description,
     repository: mainPackageJson.repository,
     scripts: {
       postinstall: rewritePrefix
-        ? 'ESY_RELEASE_REWRITE_PREFIX=true node ./postinstall.js'
-        : 'node ./postinstall.js',
+        ? "ESY_RELEASE_REWRITE_PREFIX=true node ./postinstall.js"
+        : "node ./postinstall.js"
     },
     bin: bins,
     files: [
-      '_export/',
-      'bin/',
-      'postinstall.js',
-      'esyInstallRelease.js',
-      'platform-linux/',
-      'platform-darwin/',
-      'platform-windows-x64/',
-    ],
+      "_export/",
+      "bin/",
+      "postinstall.js",
+      "esyInstallRelease.js",
+      "platform-linux/",
+      "platform-darwin/",
+      "platform-windows-x64/"
+    ]
   },
   null,
   2
 );
 
 fs.writeFileSync(
-  path.join(__dirname, '..', '..', '_release', 'package.json'),
+  path.join(__dirname, "..", "..", "_release", "package.json"),
   packageJson,
   {
-    encoding: 'utf8',
+    encoding: "utf8"
   }
 );
 
 try {
-  console.log('Copying LICENSE');
+  console.log("Copying LICENSE");
   fs.copyFileSync(
-    path.join(__dirname, '..', '..', 'LICENSE'),
-    path.join(__dirname, '..', '..', '_release', 'LICENSE')
+    path.join(__dirname, "..", "..", "LICENSE"),
+    path.join(__dirname, "..", "..", "_release", "LICENSE")
   );
 } catch (e) {
-  console.warn('No LICENSE found');
+  console.warn("No LICENSE found");
 }
 
-console.log('Copying README.md');
+console.log("Copying README.md");
 fs.copyFileSync(
-  path.join(__dirname, '..', '..', 'README.md'),
-  path.join(__dirname, '..', '..', '_release', 'README.md')
+  path.join(__dirname, "..", "..", "README.md"),
+  path.join(__dirname, "..", "..", "_release", "README.md")
 );
 
-console.log('Copying postinstall.js');
+console.log("Copying postinstall.js");
 fs.copyFileSync(
-  path.join(__dirname, 'release-postinstall.js'),
-  path.join(__dirname, '..', '..', '_release', 'postinstall.js')
+  path.join(__dirname, "release-postinstall.js"),
+  path.join(__dirname, "..", "..", "_release", "postinstall.js")
 );
 
-console.log('Creating placeholder files');
+console.log("Creating placeholder files");
 const placeholderFile = `:; echo "You need to have postinstall enabled"; exit $?
 @ECHO OFF
 ECHO You need to have postinstall enabled`;
-fs.mkdirSync(path.join(__dirname, '..', '..', '_release', 'bin'));
+fs.mkdirSync(path.join(__dirname, "..", "..", "_release", "bin"));
 
-Object.keys(bins).forEach((name) => {
+Object.keys(bins).forEach(name => {
   if (bins[name]) {
-    const binPath = path.join(__dirname, '..', '..', '_release', bins[name]);
+    const binPath = path.join(__dirname, "..", "..", "_release", bins[name]);
     fs.writeFileSync(binPath, placeholderFile);
     fs.chmodSync(binPath, 0777);
   } else {
-    console.log('bins[name] name=' + name + ' was empty. Weird.');
+    console.log("bins[name] name=" + name + " was empty. Weird.");
     console.log(bins);
   }
 });

--- a/esy.json
+++ b/esy.json
@@ -1,5 +1,5 @@
 {
-  "name": "tailwind-ppx",
+  "name": "@dylanirlbeck/tailwind-ppx",
   "version": "0.8.0",
   "description": "Reason PPX that validates your Tailwind classes at compile-time",
   "author": "Dylan Irlbeck <dylanirlbeck@gmail.com>",

--- a/esy.json
+++ b/esy.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dylanirlbeck/tailwind-ppx",
+  "name": "tailwind-ppx",
   "version": "0.8.0",
   "description": "Reason PPX that validates your Tailwind classes at compile-time",
   "author": "Dylan Irlbeck <dylanirlbeck@gmail.com>",


### PR DESCRIPTION
The last version (v0.8.0) got published under the NPM package name `tailwind-ppx` instead of `@dylanirlbeck/tailwind-ppx`. Let's change that.

TODO after this is merged please release a new v0.8.0 and delete the `tailwind-ppx` npm package so as to not confuse people.